### PR TITLE
added functionality to send directly to syslog server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,26 @@
 We at [@SchweizerischeBundesbahnen](https://github.com/SchweizerischeBundesbahnen) need to host all the OpenShift events outside our OSE-cluster as it would flood our etcd datastore if we keep the events of all projects for more than one day.
 So this tools just attaches to the kubernetes API and logs all the events to console where they are grabbed and sent to our central logging environment.
 
+# Syslog forwarding
+If SYSLOG_SERVER is defined, we will forward the logs the the syslog server instead of sending the events to the console
 
 # Installation
 ```bash
 # Create a project & a service-account
-oc new-project sbb-infra
+oc project logging
 oc create serviceaccount ose-eventforwarder
 
 # Add a new role to your cluster-policy:
-oc edit clusterPolicy default
-
-###
-- name: ose:eventforwarder
-  role:
-    metadata:
-      creationTimestamp: null
-      name: ose:eventforwarder
-    rules:
-    - apiGroups:
-      - ""
-      attributeRestrictions: null
-      resources:
-      - events
-      verbs:
-      - get
-      - list
-      - watch
-###
+oc create -f deploy/clusterPolicy-forward.yaml
 
 # Add the role to the service-account
-oc adm policy add-cluster-role-to-user ose:eventforwarder system:serviceaccount:sbb-infra:ose-eventforwarder
+oc adm policy add-cluster-role-to-user ose:eventforwarder system:serviceaccount:logging:ose-eventforwarder
+
+# Deploy the new pod
+oc create configmap forward-config \
+    --from-literal=syslog.server=\<syslogserver\>:\<syslogport\> \
+    --from-literal=syslog.tag=\<syslog tag\>
+oc create -f deploy/deploymentConfig.yaml
 ```
 
 Just create a 'oc new-app' from building the dockerfile or get it from here [Dockerhub](https://hub.docker.com/r/oscp/openshift-eventforwarder/).
@@ -41,4 +31,7 @@ Just create a 'oc new-app' from building the dockerfile or get it from here [Doc
 :-----:|:-----:|:-----:
 OPENSHIFT\_API\_URL|Your OpenShift API Url|https://master01.ch:8443
 OPENSHIFT\_TOKEN|The token of the service-account| 
-
+SYSLOG\_SERVER|The address and port of the target syslog server|syslogserver.corp.net:514
+SYSLOG\_PROTO|Select tcp or udp for protocol. Defaults to udp if not defined| tcp
+SYSLOG\_TAG|Tag to send to syslog identifying the source. Defaults to OSE if not defined| OSE\_CORP
+DEBUG|Set to send to both standardout and syslog server. Defaults to FALSE | FALSE or TRUE

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ We at [@SchweizerischeBundesbahnen](https://github.com/SchweizerischeBundesbahne
 So this tools just attaches to the kubernetes API and logs all the events to console where they are grabbed and sent to our central logging environment.
 
 # Syslog forwarding
-If SYSLOG_SERVER is defined, we will forward the logs the the syslog server instead of sending the events to the console
+The standard mode for this applicaiton is to write to standard out.  If you wish to send to Syslog instead, you can define SYSLOG_SERVER as an environment variable, and we will forward the logs the the syslog server instead of sending the events to the console/standard out.  If you wish to send to both a syslog server as well as standard out, you can define the DEBUG environment variable and it will send to both standard out and the defined syslog server.
 
 # Installation
 ```bash

--- a/deploy/clusterPolicy-forward.yaml
+++ b/deploy/clusterPolicy-forward.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ose:eventforwarder
+rules:
+- apiGroups: null
+  attributeRestrictions: null
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/deploymentConfig.yaml
+++ b/deploy/deploymentConfig.yaml
@@ -1,0 +1,37 @@
+---
+  kind: "DeploymentConfig"
+  apiVersion: "v1"
+  metadata:
+    name: "ose-eventforwarder"
+  spec:
+    template:
+      metadata:
+        labels:
+          name: "ose-eventforwarder"
+      spec:
+        containers:
+          -
+            name: "ose-eventforwarder"
+            image: >-
+              <your docker registry here>
+            env:
+            - name: SYSLOG_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: forward-config
+                  key: syslog.server
+            - name: SYSLOG_TAG
+              valueFrom:
+                configMapKeyRef:
+                  name: forward-config
+                  key: syslog.tag
+            command: ["/app/ose-event-forwarder", "" ]
+        serviceAccount: ose-eventforwarder
+        nodeSelector:
+            type: "infra"
+    replicas: 1
+    triggers:
+      -
+        type: "ConfigChange"
+    strategy:
+      type: "Rolling"

--- a/main.go
+++ b/main.go
@@ -4,14 +4,24 @@ import (
 	"bufio"
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
-	"golang.org/x/build/kubernetes/api"
+	"io"
+	"io/ioutil"
 	"log"
+	"log/syslog"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
+
+	"net"
+
+	"strings"
+
+	"golang.org/x/build/kubernetes/api"
 )
 
+// Stream : structure for holding the stream of data coming from OpenShift
 type Stream struct {
 	Type  string    `json:"type,omitempty"`
 	Event api.Event `json:"object"`
@@ -20,11 +30,98 @@ type Stream struct {
 func main() {
 	apiAddr := os.Getenv("OPENSHIFT_API_URL")
 	apiToken := os.Getenv("OPENSHIFT_TOKEN")
+	syslogServer := os.Getenv("SYSLOG_SERVER")
+	syslogProto := strings.ToLower(os.Getenv("SYSLOG_PROTO"))
+	syslogTag := strings.ToUpper(os.Getenv("SYSLOG_TAG"))
+	ignoreSSL := strings.ToUpper(os.Getenv("IGNORE_SSL"))
+	debugFlag := strings.ToUpper(os.Getenv("DEBUG"))
 
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	// enable signal trapping
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c,
+			syscall.SIGINT,  // Ctrl+C
+			syscall.SIGTERM, // Termination Request
+			syscall.SIGSEGV, // FullDerp
+			syscall.SIGABRT, // Abnormal termination
+			syscall.SIGILL,  // illegal instruction
+			syscall.SIGFPE)  // floating point
+		sig := <-c
+		log.Fatalf("Signal (%v) Detected, Shutting Down", sig)
+	}()
+
+	// check and make sure we have the minimum config information before continuing
+	if apiAddr == "" {
+		// use the default internal cluster URL if not defined
+		apiAddr = "https://openshift.default.svc.cluster.local"
+		ignoreSSL = "TRUE"
+		log.Print("Missing environment variable OPENSHIFT_API_URL. Using default API URL")
 	}
-	client := &http.Client{Transport: tr}
+	if apiToken == "" {
+		// if we dont set it in the environmetn, why not read it out of
+		// /var/run/secrets/kubernetes.io/serviceaccount/token
+		log.Print("Missing environment variable OPENSHIFT_TOKEN. Leveraging serviceaccount token")
+		fileData, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+		if err != nil {
+			log.Fatal("Service Account token does not exist.")
+		}
+		apiToken = string(fileData)
+	}
+	if syslogTag == "" {
+		// we dont need to error out here, but we do need to set a default if the variable isnt defined
+		syslogTag = "OSE"
+	}
+	if ignoreSSL == "" {
+		// we dont need to error out here, but we do need to set a default if the variable isnt defined
+		ignoreSSL = "FALSE"
+	}
+	if debugFlag == "" {
+		// we dont need to error out here, but we do need to set a default if the variable isnt defined
+		debugFlag = "FALSE"
+	}
+	if (syslogProto == "") || (syslogProto == "tcp") || (syslogProto == "udp") {
+		// we dont need to error out here, but we do need to set a default if the variable isnt defined
+		if syslogProto == "" {
+			log.Print("SYSLOG_PROTO not set, defaulting to udp")
+			syslogProto = "udp"
+		} else {
+			log.Printf("Will use %s for syslog protocol", syslogProto)
+		}
+
+	} else {
+		log.Fatalf("SYSLOG_PROTO must be either blank, or tcp or udp not %s", syslogProto)
+	}
+
+	// Setup syslog connection only if syslogServer is defined
+	if syslogServer != "" {
+		sysLog, err := syslog.Dial(syslogProto, syslogServer,
+			syslog.LOG_WARNING|syslog.LOG_DAEMON, syslogTag)
+		if err != nil {
+			log.Printf("Error connecting to %s", syslogServer)
+			log.Fatal(err)
+		} else {
+			log.Printf("Event Forwarder configured to send all events to %s using tag %s", syslogServer, syslogTag)
+			if debugFlag == "TRUE" {
+				// dump the data to stdout AND syslog for testing.
+				log.SetOutput(io.MultiWriter(sysLog, os.Stdout))
+				ipAddr, _ := net.LookupHost(syslogServer)
+				log.Printf("Connecting to IP address: %v\n", ipAddr)
+			} else {
+				log.SetOutput(sysLog)
+			}
+		}
+	} else {
+		log.Print("SYSLOG_SERVER environment variable not set. Sending all output to console.")
+	}
+
+	// setup ose connection
+	var client http.Client
+	if ignoreSSL == "TRUE" {
+		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		client = http.Client{Transport: tr}
+	} else {
+		client = http.Client{}
+	}
 	req, err := http.NewRequest("GET", apiAddr+"/api/v1/events?watch=true", nil)
 	if err != nil {
 		log.Fatal("## Error while opening connection to openshift api", err)
@@ -53,15 +150,15 @@ func main() {
 			event := Stream{}
 			decErr := json.Unmarshal(line, &event)
 			if decErr != nil {
-				log.Println("## Error decoding json", err)
+				log.Println("## Error decoding json.", err)
 				resp.Body.Close()
 				break
 			}
-
-			fmt.Printf("%v | Project: %v | Name: %v | Kind: %v | Reason: %v | Message: %v\n",
-				event.Event.LastTimestamp,
-				event.Event.Namespace, event.Event.Name,
+			// using "|" to seperate each field for easy parsing by log analyzers
+			log.Printf("| Project: %v | Time: %v | Name: %v | Kind: %v | Reason: %v | Message: %v",
+				event.Event.Namespace, event.Event.LastTimestamp, event.Event.Name,
 				event.Event.Kind, event.Event.Reason, event.Event.Message)
 		}
 	}
+
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -58,7 +59,7 @@ func main() {
 		log.Print("Missing environment variable OPENSHIFT_API_URL. Using default API URL")
 	}
 	if apiToken == "" {
-		// if we dont set it in the environmetn, why not read it out of
+		// if we dont set it in the environment variable, read it out of
 		// /var/run/secrets/kubernetes.io/serviceaccount/token
 		log.Print("Missing environment variable OPENSHIFT_TOKEN. Leveraging serviceaccount token")
 		fileData, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
@@ -154,9 +155,10 @@ func main() {
 				resp.Body.Close()
 				break
 			}
-			// using "|" to seperate each field for easy parsing by log analyzers
-			log.Printf("| Project: %v | Time: %v | Name: %v | Kind: %v | Reason: %v | Message: %v",
-				event.Event.Namespace, event.Event.LastTimestamp, event.Event.Name,
+
+			fmt.Printf("%v | Project: %v | Name: %v | Kind: %v | Reason: %v | Message: %v\n",
+				event.Event.LastTimestamp,
+				event.Event.Namespace, event.Event.Name,
 				event.Event.Kind, event.Event.Reason, event.Event.Message)
 		}
 	}


### PR DESCRIPTION
added ability to forward logs directly to a syslog server for processing, or direct to console, or both
added deployment files for alternate deployment process
updated program to use default token and internal url to simplify deployment
updated README.md to reflect the changes